### PR TITLE
Add Laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,12 +23,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.1]
-        laravel: [10.*]
+        php: [8.3, 8.2]
+        laravel: [10.*, 11.*]
         stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
+            carbon: ^2.63
+          - laravel: 11.*
+            testbench: 9.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.21",
+        "illuminate/contracts": "^10.21|^11",
         "laravel/pulse": "^1.0@beta",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^7.8|^8.1",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.14",
+        "orchestra/testbench": "^8.14|^9.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "illuminate/contracts": "^10.21|^11",
         "laravel/pulse": "^1.0",
         "spatie/laravel-package-tools": "^1.14.0"


### PR DESCRIPTION
Adds Laravel 11 support

I did run the tests, however 1 test is failing for me:

```sh
   FAIL  Tests\FourXXCardTest
  ⨯ it renders 4xx requests                                                                                                                                                0.01s
  ✓ it includes the card on the dashboard                                                                                                                                  0.04s
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   FAILED  Tests\FourXXCardTest > it renders 4xx requests                                                                                                    ArgumentCountError
  Too few arguments to function Laravel\Pulse\Storage\DatabaseStorage::store(), 0 passed in /[...]/laravel-pulse-4xx/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php on line 23 and exactly 1 expected

  at vendor/laravel/pulse/src/Storage/DatabaseStorage.php:42
     38▕      * Store the items.
     39▕      *
     40▕      * @param  \Illuminate\Support\Collection<int, \Laravel\Pulse\Entry|\Laravel\Pulse\Value>  $items
     41▕      */
  ➜  42▕     public function store(Collection $items): void
     43▕     {
     44▕         if ($items->isEmpty()) {
     45▕             return;
     46▕         }

      +6 vendor frames
  7   tests/FourXXCardTest.php:35
```
This test also fails for me on the main branch, with the same error. So I think I'm missing something regarding setup.