### PR TITLE
Prefix request path with `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,24 @@ composer require morrislaptop/laravel-pulse-4xx
 
 Add the `FourXxRecorder` to the `config/pulse.php` file. 
 
-```diff
+```php
 return [
     // ...
+
     'recorders' => [
-+       \Morrislaptop\LaravelPulse4xx\FourXxRecorder::class => [
-+           'enabled' => env('PULSE_4XX_ENABLED', true),
-+           'sample_rate' => env('PULSE_4XX_SAMPLE_RATE', 1),
-+           'ignore' => [
-+               '#^/wp-admin#', // Classic WordPress...
-+           ],
-+       ],
+        Morrislaptop\LaravelPulse4xx\FourXxRecorder::class => [
+            'enabled' => env('PULSE_4XX_ENABLED', true),
+            'sample_rate' => env('PULSE_4XX_SAMPLE_RATE', 1),
+            'ignore' => [
+                '#^/wp-admin#', // Classic WordPress...
+                '#^/wp-login#',
+                '#^/wp-config#',
+                '#^/xmlrpc\.php#',
+                '#^/browserconfig\.xml#', // Microsoft junk
+            ],
+        ],
+
+        // ...
     ]
 ]
 ```
@@ -44,30 +51,13 @@ To add the card to the Pulse dashboard, you must first [publish the vendor view]
 php artisan vendor:publish --tag=pulse-dashboard
 ```
 
-Then, you can modify the `dashboard.blade.php` file:
+Then, add the card to your `resources/views/vendor/pulse/dashboard.php`:
 
-```diff
+```blade
 <x-pulse>
-+   <livewire:4xx cols='4' rows='2' />
+    <livewire:4xx cols="4" rows="2" />
 
-    <livewire:pulse.servers cols="full" />
-
-    <livewire:pulse.usage cols="4" rows="2" />
-
-    <livewire:pulse.queues cols="4" />
-
-    <livewire:pulse.cache cols="4" />
-
-    <livewire:pulse.slow-queries cols="8" />
-
-    <livewire:pulse.exceptions cols="6" />
-
-    <livewire:pulse.slow-requests cols="6" />
-
-    <livewire:pulse.slow-jobs cols="6" />
-
-    <livewire:pulse.slow-outgoing-requests cols="6" />
-
+    <!-- ... -->
 </x-pulse>
 ```
 

--- a/src/FourXxRecorder.php
+++ b/src/FourXxRecorder.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Laravel\Pulse\Concerns\ConfiguresAfterResolving;
 use Laravel\Pulse\Pulse;
 use Laravel\Pulse\Recorders\Concerns;
@@ -46,7 +47,7 @@ class FourXxRecorder
             return;
         }
 
-        $path = $request->path();
+        $path = Str::start($request->path(), '/');
 
         if ($this->shouldIgnore($path)) {
             return;


### PR DESCRIPTION
AFAIK, most other Pulse cards are prefixing the `Request` path with a `/`, e.g. [timacdonald/pulse-validation-errors](https://github.com/timacdonald/pulse-validation-errors) or the built-in `Recorders\SlowRequests`.

In your README, you were already using a leading slash in the ignore pattern example (`#^/wp-admin#`), which previously was not working as it was matched against `wp-admin`.

I have also updated the README with some other common ignore patterns and made it easier to copy-paste the recorders section.